### PR TITLE
Quote parameters for 'get_option()' and 'files()' as for 'dependency()'

### DIFF
--- a/src/liblangserver/completion.cpp
+++ b/src/liblangserver/completion.cpp
@@ -464,7 +464,7 @@ specialStringLiteralAutoCompletion(const StringLiteral *literal,
     // TODO: Works in Builder, but not in VSCode
     ret.emplace_back(
         relative, CompletionItemKind::CIK_FILE,
-        TextEdit(nodeToRange(literal), std::format("{}", relative)));
+        TextEdit(nodeToRange(literal), std::format("'{}'", relative)));
   }
 }
 
@@ -493,7 +493,7 @@ static void specialStringLiteralAutoCompletion(
         // TODO: Works in Builder, but not in VSCode
         ret.emplace_back(
             opt->name, CompletionItemKind::CIK_FILE,
-            TextEdit(nodeToRange(literal), std::format("{}", opt->name)));
+            TextEdit(nodeToRange(literal), std::format("'{}'", opt->name)));
       }
     }
 


### PR DESCRIPTION
Replace this paragraph with a description of your changes and rationale.

Checklist:
- [ ] Did you update the CHANGELOG?
- [ ] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?
- [ ] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?

Fixes #NNNN
