### PR TITLE
libcxathrow: Fix build on Musl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update API level to Oct. 16 2024
 - Fix adding newline at the end for formatting
 - Fixed types of cmake_subprojectoptions::append_link_args
+- Fixed compilation under Musl
 
 # 4.3.4 (Sep 01 2024)
 - Fix crash if first statement of root meson.build is not a function call (#135)

--- a/src/libcxathrow/meson.build
+++ b/src/libcxathrow/meson.build
@@ -17,7 +17,11 @@ if cxx.get_id() == 'gcc'
         src_files += 'backtrace_stacktrace.cpp'
         cxathrow_deps += backtrace_dep
     else
-        if is_static or host_machine.system() == 'windows'
+        if not cxx.has_header('execinfo.h')
+            # Musl libc doesn't have execinfo.h
+            src_files += null_backtrace
+            used_libunwind = libunwind_dep.found()
+        elif is_static or host_machine.system() == 'windows'
             # Should only happen in crappy distributions....
             src_files += null_backtrace
             used_libunwind = true


### PR DESCRIPTION
I do not consider this change to be fully polished (but I left the code in a better state than it was in). I am open to discussion about the problematic of determining correct exception unwinding mechanism on different operating systems/libcs.

My intent is to package mesonlsp. To be honest, I expected a LSP _for Meson_ to have a cleaner build process. This project depends on a lot of "[throwaway](https://github.com/JCWasmx86/tree-sitter-ini) [forks](https://github.com/JCWasmx86/muon)" of popular libraries/projects with few custom commits added. As a package maintainer, I would prefer to see more robust solutions, and if they aren't feasible, I would like to see documented commitments to maintain these forks, to "backport" upstream updates and to release/tag versions every so often. [The muon fork](https://github.com/JCWasmx86/muon) is especially discouraging. The current latest release is also not buildable (because it lacks 8edb5af16db9d7651a88ae19d0574195a02e40b6).

But I understand that maintaining an open-source project is a difficult task (I have also noticed the call for maintainers). I intend my comments to be constructive criticism for areas which could be improved if the project wishes to spend its limited resources on improving the packaging experience.

To return to the focus of this PR, I would also like to note that the libunwind optional dependency should be documented somewhere. If I hadn't encountered issues with building mesonlsp on Musl which lead me to `src/libcxathrow/meson.build`, I wouldn't have noticed this dependency and I would have packaged a version of mesonlsp which wouldn't print any useful stacktraces on Musl. If there is interest, I am willing to collaborate on improving this documentation (but mesonlsp currently doesn't have a dedicated place to document the build or packaging process, it has only a brief shell snippet in README).

Checklist:
- [x] Did you update the CHANGELOG?
- [ ] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?
- [ ] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?

related to #174